### PR TITLE
Update Node requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## Contribution
 
 Anyone is more than welcome to contribute. Before you can run this web app on your local machine you need to have installed:
-* [Node.js](http://nodejs.org/)
+* [Node.js](http://nodejs.org/) (version 18 or later)
 * [MongoDB](https://www.mongodb.org/)
 * [npm](https://github.com/npm/npm)
 * [Node Canvas](https://github.com/Automattic/node-canvas)

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "url": "https://github.com/meanjs/mean.git"
   },
   "engines": {
-    "node": "0.12.x",
-    "npm": "2.5.1"
+    "node": ">=18",
+    "npm": ">=9"
   },
   "scripts": {
     "start": "grunt",


### PR DESCRIPTION
## Summary
- modernize Node.js and npm requirements in `package.json`
- note Node 18+ requirement in README

## Testing
- `npm test` *(fails: Cannot find module 'load-grunt-tasks')*

------
https://chatgpt.com/codex/tasks/task_e_68540e438cdc832b9e6f4652520827fc